### PR TITLE
fix: incomplete multi-character sanitization

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -14,7 +14,26 @@ export function formatDate(date: Date) {
 }
 
 export function readingTime(html: string) {
-  const textOnly = html.replace(/[<>]/g, "");
+  let textOnly = "";
+  let inTag = false;
+  let quoteChar = "";
+
+  for (const char of html) {
+    if (inTag) {
+      if (quoteChar) {
+        if (char === quoteChar) quoteChar = "";
+      } else if (char === "\"" || char === "'") {
+        quoteChar = char;
+      } else if (char === ">") {
+        inTag = false;
+      }
+    } else if (char === "<") {
+      inTag = true;
+    } else {
+      textOnly += char;
+    }
+  }
+
   const wordCount = textOnly.split(/\s+/).length;
   const readingTimeMinutes = ((wordCount / 200) + 1).toFixed();
   return `${readingTimeMinutes} min read`;

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -16,12 +16,19 @@ export function formatDate(date: Date) {
 export function readingTime(html: string) {
   const textOnlyChars: string[] = [];
   let inTag = false;
-  let quoteChar = "";
+  let quoteChar: "\"" | "'" | null = null;
+  let escapedInQuote = false;
 
   for (const char of html) {
     if (inTag) {
-      if (quoteChar) {
-        if (char === quoteChar) quoteChar = "";
+      if (quoteChar !== null) {
+        if (escapedInQuote) {
+          escapedInQuote = false;
+        } else if (char === "\\") {
+          escapedInQuote = true;
+        } else if (char === quoteChar) {
+          quoteChar = null;
+        }
       } else if (char === "\"" || char === "'") {
         quoteChar = char;
       } else if (char === ">") {

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -14,7 +14,7 @@ export function formatDate(date: Date) {
 }
 
 export function readingTime(html: string) {
-  const textOnly = html.replace(/<[^>]+>/g, "");
+  const textOnly = html.replace(/[<>]/g, "");
   const wordCount = textOnly.split(/\s+/).length;
   const readingTimeMinutes = ((wordCount / 200) + 1).toFixed();
   return `${readingTimeMinutes} min read`;

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -14,7 +14,7 @@ export function formatDate(date: Date) {
 }
 
 export function readingTime(html: string) {
-  let textOnly = "";
+  const textOnlyChars: string[] = [];
   let inTag = false;
   let quoteChar = "";
 
@@ -30,12 +30,14 @@ export function readingTime(html: string) {
     } else if (char === "<") {
       inTag = true;
     } else {
-      textOnly += char;
+      textOnlyChars.push(char);
     }
   }
 
-  const wordCount = textOnly.split(/\s+/).length;
-  const readingTimeMinutes = ((wordCount / 200) + 1).toFixed();
+  const textOnly = textOnlyChars.join("");
+  const trimmedText = textOnly.trim();
+  const safeWordCount = trimmedText ? trimmedText.split(/\s+/).length : 0;
+  const readingTimeMinutes = ((safeWordCount / 200) + 1).toFixed();
   return `${readingTimeMinutes} min read`;
 }
 


### PR DESCRIPTION
Potential fix for [https://github.com/rdhar/rdhar.dev/security/code-scanning/1](https://github.com/rdhar/rdhar.dev/security/code-scanning/1)

Use a safe, deterministic transformation for counting words that cannot leave partially reconstructed tags. The best minimal fix here is to avoid multi-character tag stripping entirely and instead remove angle brackets as single characters (`<` and `>`), which eliminates the specific re-formation issue CodeQL flags while preserving the function’s behavior (derive text-ish content for word counting).

In `src/lib/utils.ts`, update `readingTime` line 17 from:
- `html.replace(/<[^>]+>/g, "")`
to:
- `html.replace(/[<>]/g, "")`

No new imports or helper methods are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
