### PR TITLE
chore: remove email, fix readingTime/favicon, polish

### DIFF
--- a/src/components/Head.astro
+++ b/src/components/Head.astro
@@ -20,7 +20,6 @@ const { title, description, image = "/nano.png" } = Astro.props;
 <meta name="viewport" content="width=device-width,initial-scale=1" />
 <link rel="icon" type="image/svg+xml" href="/favicon-dark.svg" media="(prefers-color-scheme: dark)" />
 <link rel="icon" type="image/svg+xml" href="/favicon-light.svg" media="(prefers-color-scheme: light)" />
-<link rel="icon" type="image/x-icon" href="/favicon-light.svg" />
 <meta name="generator" content={Astro.generator} />
 
 <!-- Canonical URL -->

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -2,7 +2,6 @@ import type { Site, Metadata, Socials } from "@types";
 
 export const SITE: Site = {
   NAME: "Rishav Dhar",
-  EMAIL: "hi",
   NUM_POSTS_ON_HOMEPAGE: 2,
   NUM_WORKS_ON_HOMEPAGE: 2,
   NUM_PROJECTS_ON_HOMEPAGE: 1,

--- a/src/layouts/PageLayout.astro
+++ b/src/layouts/PageLayout.astro
@@ -7,15 +7,16 @@ import { SITE } from "@consts";
 type Props = {
   title: string;
   description: string;
+  image?: string;
 };
 
-const { title, description } = Astro.props;
+const { title, description, image } = Astro.props;
 ---
 
 <!doctype html>
 <html lang="en">
   <head>
-    <Head title={`${title} | ${SITE.NAME}`} description={description} />
+    <Head title={`${title} | ${SITE.NAME}`} description={description} image={image} />
   </head>
   <body>
     <Header />

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -5,12 +5,19 @@ export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
 
+const fullDateFormatter = new Intl.DateTimeFormat("en-US", {
+  month: "short",
+  day: "2-digit",
+  year: "numeric",
+});
+
+const monthYearFormatter = new Intl.DateTimeFormat("en-US", {
+  month: "short",
+  year: "numeric",
+});
+
 export function formatDate(date: Date) {
-  return Intl.DateTimeFormat("en-US", {
-    month: "short",
-    day: "2-digit",
-    year: "numeric"
-  }).format(date);
+  return fullDateFormatter.format(date);
 }
 
 export function readingTime(html: string) {
@@ -43,26 +50,19 @@ export function readingTime(html: string) {
 
   const textOnly = textOnlyChars.join("");
   const trimmedText = textOnly.trim();
-  const safeWordCount = trimmedText ? trimmedText.split(/\s+/).length : 0;
-  const readingTimeMinutes = ((safeWordCount / 200) + 1).toFixed();
-  return `${readingTimeMinutes} min read`;
+  const wordCount = trimmedText ? trimmedText.split(/\s+/).length : 0;
+  const minutes = Math.max(1, Math.ceil(wordCount / 200));
+  return `${minutes} min read`;
 }
 
 export function dateRange(startDate: Date, endDate?: Date | string): string {
-  const startMonth = startDate.toLocaleString("default", { month: "short" });
-  const startYear = startDate.getFullYear().toString();
-  let endMonth;
-  let endYear;
+  const start = monthYearFormatter.format(startDate);
+  const end =
+    endDate === undefined
+      ? ""
+      : typeof endDate === "string"
+        ? endDate
+        : monthYearFormatter.format(endDate);
 
-  if (endDate) {
-    if (typeof endDate === "string") {
-      endMonth = "";
-      endYear = endDate;
-    } else {
-      endMonth = endDate.toLocaleString("default", { month: "short" });
-      endYear = endDate.getFullYear().toString();
-    }
-  }
-
-  return `${startMonth}${startYear} - ${endMonth}${endYear}`;
+  return `${start} - ${end}`;
 }

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -4,7 +4,7 @@ import Container from "@components/Container.astro";
 import PageLayout from "@layouts/PageLayout.astro";
 import Link from "@components/Link.astro";
 import { dateRange } from "@lib/utils";
-import { SITE, HOME, SOCIALS } from "@consts";
+import { HOME, SITE, SOCIALS } from "@consts";
 
 const allwork = (await getCollection("work"))
   .sort(
@@ -120,12 +120,12 @@ const work = await Promise.all(
         <article>
           <p>
             If you want to get in touch with me about something or just to say
-            hi, reach out on social media or send me an email.
+            hi, reach out on social media.
           </p>
         </article>
         <ul class="flex flex-wrap gap-2">
           {
-            SOCIALS.map((SOCIAL) => (
+            SOCIALS.map((SOCIAL, index) => (
               <li class="flex gap-x-2 text-nowrap">
                 <Link
                   href={SOCIAL.HREF}
@@ -134,18 +134,10 @@ const work = await Promise.all(
                 >
                   {SOCIAL.NAME}
                 </Link>
-                {"/"}
+                {index < SOCIALS.length - 1 && "/"}
               </li>
             ))
           }
-          <li class="line-clamp-1">
-            <Link
-              href={`mailto:${SITE.EMAIL}`}
-              aria-label={`Email ${SITE.NAME}`}
-            >
-              {SITE.EMAIL}
-            </Link>
-          </li>
         </ul>
       </section>
     </div>

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,5 @@
 export type Site = {
   NAME: string;
-  EMAIL: string;
   NUM_POSTS_ON_HOMEPAGE: number;
   NUM_WORKS_ON_HOMEPAGE: number;
   NUM_PROJECTS_ON_HOMEPAGE: number;


### PR DESCRIPTION
## Summary
- Drop `SITE.EMAIL` and the homepage mailto link block (placeholder value).
- Fix `readingTime` reporting at least 1 extra minute (was `(words/200)+1`, now `Math.max(1, Math.ceil(words/200))`).
- Remove the `rel=icon type=image/x-icon` line that pointed at an SVG.
- Forward an optional `image` prop from `PageLayout` into `Head` for per-page OG images.
- Consolidate `formatDate` / `dateRange` on cached `Intl.DateTimeFormat` instances. `dateRange` now renders `Mon YYYY - Mon YYYY` instead of the run-together `MonYYYY - MonYYYY`.

## Test plan
- [x] `bun run astro check` — 0 errors / warnings / hints
- [x] `bun run build` — 14 pages built
- [ ] Visual check: homepage no longer shows email link; work entries render with spaced date range
- [ ] Visual check: favicon still loads in light/dark scheme

🤖 Generated with [Claude Code](https://claude.com/claude-code)