### PR TITLE
refactor: centralize content collection queries

### DIFF
--- a/src/lib/content.ts
+++ b/src/lib/content.ts
@@ -1,0 +1,26 @@
+import { type CollectionEntry, getCollection } from "astro:content";
+
+type Publishable = CollectionEntry<"blog"> | CollectionEntry<"projects">;
+
+function byPubDateDesc(a: Publishable, b: Publishable) {
+  return b.data.pubDate.valueOf() - a.data.pubDate.valueOf();
+}
+
+function byDateStartDesc(a: CollectionEntry<"work">, b: CollectionEntry<"work">) {
+  return b.data.dateStart.valueOf() - a.data.dateStart.valueOf();
+}
+
+export async function getPublishedBlogPosts() {
+  const posts = await getCollection("blog");
+  return posts.filter((post) => !post.data.draft).sort(byPubDateDesc);
+}
+
+export async function getPublishedProjects() {
+  const projects = await getCollection("projects");
+  return projects.filter((project) => !project.data.draft).sort(byPubDateDesc);
+}
+
+export async function getSortedWork() {
+  const work = await getCollection("work");
+  return work.sort(byDateStartDesc);
+}

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -1,15 +1,14 @@
 ---
-import { type CollectionEntry, getCollection, render } from "astro:content";
+import { type CollectionEntry, render } from "astro:content";
 import PageLayout from "@layouts/PageLayout.astro";
 import Container from "@components/Container.astro";
 import FormattedDate from "@components/FormattedDate.astro";
+import { getPublishedBlogPosts } from "@lib/content";
 import { readingTime } from "@lib/utils";
 import BackToPrev from "@components/BackToPrev.astro";
 
 export async function getStaticPaths() {
-  const posts = (await getCollection("blog"))
-    .filter(post => !post.data.draft)
-    .sort((a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf());
+  const posts = await getPublishedBlogPosts();
   return posts.map((post) => ({
     params: { slug: post.id },
     props: post,

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -1,14 +1,13 @@
 ---
-import { type CollectionEntry, getCollection } from "astro:content";
+import type { CollectionEntry } from "astro:content";
 import PageLayout from "@layouts/PageLayout.astro";
 import Container from "@components/Container.astro";
 import ArrowCard from "@components/ArrowCard.astro";
+import { getPublishedBlogPosts } from "@lib/content";
 import { BLOG } from "@consts";
 
-const data = (await getCollection("blog"))
-  .filter(post => !post.data.draft)
-  .sort((a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf());
-  
+const data = await getPublishedBlogPosts();
+
 type Acc = {
   [year: string]: CollectionEntry<"blog">[];
 }

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,18 +1,13 @@
 ---
-import { getCollection, render } from "astro:content";
+import { render } from "astro:content";
 import Container from "@components/Container.astro";
 import PageLayout from "@layouts/PageLayout.astro";
 import Link from "@components/Link.astro";
+import { getSortedWork } from "@lib/content";
 import { dateRange } from "@lib/utils";
 import { SITE, HOME, SOCIALS } from "@consts";
 
-const allwork = (await getCollection("work"))
-  .sort(
-    (a, b) =>
-      new Date(b.data.dateStart).valueOf() -
-      new Date(a.data.dateStart).valueOf(),
-  )
-  .slice(0, SITE.NUM_WORKS_ON_HOMEPAGE);
+const allwork = (await getSortedWork()).slice(0, SITE.NUM_WORKS_ON_HOMEPAGE);
 
 const work = await Promise.all(
   allwork.map(async (item) => {

--- a/src/pages/projects/[...slug].astro
+++ b/src/pages/projects/[...slug].astro
@@ -1,16 +1,15 @@
 ---
-import { type CollectionEntry, getCollection, render } from "astro:content";
+import { type CollectionEntry, render } from "astro:content";
 import PageLayout from "@layouts/PageLayout.astro";
 import Container from "@components/Container.astro";
 import FormattedDate from "@components/FormattedDate.astro";
+import { getPublishedProjects } from "@lib/content";
 import { readingTime } from "@lib/utils";
 import BackToPrev from "@components/BackToPrev.astro";
 import Link from "@components/Link.astro";
 
 export async function getStaticPaths() {
-  const projects = (await getCollection("projects"))
-    .filter(post => !post.data.draft)
-    .sort((a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf());
+  const projects = await getPublishedProjects();
   return projects.map((project) => ({
     params: { slug: project.id },
     props: project,

--- a/src/pages/projects/index.astro
+++ b/src/pages/projects/index.astro
@@ -1,13 +1,11 @@
 ---
-import { getCollection } from "astro:content";
 import PageLayout from "@layouts/PageLayout.astro";
 import Container from "@components/Container.astro";
 import ArrowCard from "@components/ArrowCard.astro";
+import { getPublishedProjects } from "@lib/content";
 import { PROJECTS } from "@consts";
 
-const projects = (await getCollection("projects"))
-  .filter(project => !project.data.draft)
-  .sort((a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf());
+const projects = await getPublishedProjects();
 ---
 
 <PageLayout title={PROJECTS.TITLE} description={PROJECTS.DESCRIPTION}>

--- a/src/pages/rss.xml.ts
+++ b/src/pages/rss.xml.ts
@@ -1,11 +1,13 @@
 import rss from "@astrojs/rss";
 import type { APIContext } from "astro";
-import { getCollection } from "astro:content";
+import { getPublishedBlogPosts, getPublishedProjects } from "@lib/content";
 import { HOME } from "@consts";
 
 export async function GET(context: APIContext) {
-  const blog = (await getCollection("blog")).filter(post => !post.data.draft);
-  const projects = (await getCollection("projects")).filter(project => !project.data.draft);
+  const [blog, projects] = await Promise.all([
+    getPublishedBlogPosts(),
+    getPublishedProjects(),
+  ]);
 
   const items = [...blog, ...projects]
     .sort((a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf());

--- a/src/pages/work/index.astro
+++ b/src/pages/work/index.astro
@@ -1,12 +1,12 @@
 ---
-import { getCollection, render } from "astro:content";
+import { render } from "astro:content";
 import PageLayout from "@layouts/PageLayout.astro";
 import Container from "@components/Container.astro";
+import { getSortedWork } from "@lib/content";
 import { dateRange } from "@lib/utils";
 import { WORK } from "@consts";
 
-const collection = (await getCollection("work"))
-  .sort((a, b) => new Date(b.data.dateStart).valueOf() - new Date(a.data.dateStart).valueOf());
+const collection = await getSortedWork();
 
 const work = await Promise.all(
   collection.map(async (item) => {


### PR DESCRIPTION
## Summary
The same \`getCollection(...).filter(!draft).sort(pubDate)\` chain was duplicated across blog index, blog detail (\`getStaticPaths\`), projects index, projects detail, the RSS feed, and the homepage work listing — six copies with subtly different variable names.

Extract to \`src/lib/content.ts\`:
- \`getPublishedBlogPosts()\` — filter draft + sort pubDate desc
- \`getPublishedProjects()\` — same
- \`getSortedWork()\` — sort dateStart desc

Call sites lose 1–7 lines each; one source of truth for what "published" means.

## Test plan
- [x] \`bun run astro check\` — 0 errors
- [x] \`bun run build\` — 14 pages built; same routes generated
- [ ] Manual: blog/projects index pages still hide drafts and order by pubDate desc
- [ ] Manual: \`/rss.xml\` still includes posts + projects, sorted

🤖 Generated with [Claude Code](https://claude.com/claude-code)